### PR TITLE
replace buggy fingerprint matching regex search, handle error reading frame images

### DIFF
--- a/ffmpeg_fingerprint.py
+++ b/ffmpeg_fingerprint.py
@@ -77,9 +77,16 @@ def get_fingerprint_ffmpeg(path, frame_nb, log_level=1, log_file=False, log_time
     video_fingerprint = ""
     for ndx in range(1, frame_nb + 1):
         filename = os.path.join(data_path, "fingerprints/" + replace(path) + "/frames/frame-%s.jpeg" % str(ndx).rjust(8, "0"))
-        with Image.open(filename) as image:
-            frame_fingerprint = str(imagehash.dhash(image))
-            video_fingerprint += frame_fingerprint
+        if not os.path.exists(filename):
+            print_debug(a=["Error - Possible Corruption - frame file missing: %s for video %s" % (filename, path)], log=log_level > 0, log_file=log_file)
+            break
+        try:
+            with Image.open(filename) as image:
+                frame_fingerprint = str(imagehash.dhash(image))
+                video_fingerprint += frame_fingerprint
+        except BaseException as err:
+            print_debug(a=["Error - Possible Corruption - frame file error: %s : %s" % (filename, err.strerror)], log=log_level > 0, log_file=log_file)
+            break
     try:
         shutil.rmtree(os.path.join(data_path, "fingerprints/" + replace(path) + "/frames"))
     except OSError as e:

--- a/ytube_scrape.py
+++ b/ytube_scrape.py
@@ -1,0 +1,60 @@
+import os
+import sys
+import getopt
+from pathlib import Path
+from datetime import datetime
+
+config_path = os.environ['CONFIG_DIR'] if 'CONFIG_DIR' in os.environ else './config'
+data_path = os.environ['DATA_DIR'] if 'DATA_DIR' in os.environ else os.path.join(config_path, 'data')
+
+session_timestamp = datetime.now().strftime("%Y_%m_%d-%I_%M_%S_%p")
+
+
+def print_debug(a=[], log=True, log_file=False):
+    # Here a is the array holding the objects
+    # passed as the argument of the function
+    output = ' '.join([str(elem) for elem in a])
+    if log:
+        print(output, file=sys.stderr)
+    if log_file:
+        log_path = os.path.join(config_path, 'logs')
+        Path(log_path).mkdir(parents=True, exist_ok=True)
+        with open(os.path.join(log_path, 'log_%s.txt' % session_timestamp), "a") as logger:
+            logger.write(output + '\n')
+
+
+def get_video(name='', log_level=0, log_file=False, cleanup=True, log_timestamp=None):
+    print(name)
+
+
+def main(argv):
+
+    name = ''
+    log_level = 0
+    cleanup = False
+    log = False
+    try:
+        opts, args = getopt.getopt(argv, "hi:dvcl")
+    except getopt.GetoptError:
+        print_debug(['ytube_scrape.py -i <show season> -v (verbose - some logging) -d (debug - most logging) -l (log to file)\n'])
+        sys.exit(2)
+
+    for opt, arg in opts:
+        if opt == '-h':
+            print_debug(['decode.py -i <path> -v (verbose - some logging) -d (debug - most logging) -l (log to file)\n'])
+            sys.exit()
+        elif opt == '-i':
+            name = arg
+        elif opt == '-l':
+            log = True
+        elif opt == '-d':
+            log_level = 2
+        elif opt == '-v':
+            log_level = 1
+
+    result = get_video(name=name, log_level=log_level, log_file=log, cleanup=cleanup)
+    print(result)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
**Changes**
* replaced regex for turning list of matched frames -> start, end frames.
  Replaced by the frame matching logic having the frames just keep track of their own number.
  This should result in far less errors, and a marginal speedup

* catch errors where a frame image either doesn't exist or can't be opened/read/turned into a PIL image.
  This is handled by ending the addition of new segments to the fingerprint, potentially leaving a partial fingerprint.
  The upside of that is it's possible the file could still be processed with a partial fingerprint.
  The downside is that it could allow other issues to go unnoticed.

**Issues**
* the regex used to take the matched frames and turn them into start and end frames was buggy and often resulted in the wrong start time.
* should fix #6 