### PR TITLE
start comparing at frame 1 - fixes start time alternating between correct and incorrect value

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -84,7 +84,7 @@ def create_video_fingerprint(profile, log_level, log_file):
     video_fingerprint = ''
 
     quarter_frames_or_first_X_mins = min(int(profile['total_frames'] / 4), int(profile['fps'] * 60 * max_fingerprint_mins))
-    video_fingerprint = get_fingerprint_ffmpeg(profile['path'], quarter_frames_or_first_X_mins, log_level, log_file, session_timestamp)
+    video_fingerprint = get_fingerprint_ffmpeg(profile['path'], quarter_frames_or_first_X_mins, log_level, log_file, session_timestamp, False)
 
     return video_fingerprint
 
@@ -101,8 +101,8 @@ def get_equal_frames(print1, print2, start1, start2):
 
 def get_start_end(print1, print2):
     highest_equal_frames = []
-    for k in range(0, int(len(print1) / 16)):
-        equal_frames = get_equal_frames(print1[-k * 16:], print2, (len(print1) / 16) - k, 0)
+    for k in range(1, int(len(print1) / 16)):
+        equal_frames = get_equal_frames(print1[-k * 16:], print2, int(len(print1) / 16) - k, 0)
         if len(equal_frames) > len(highest_equal_frames):
             highest_equal_frames = equal_frames
         equal_frames = get_equal_frames(print1, print2[k * 16:], 0, k)

--- a/ffmpeg_fingerprint.py
+++ b/ffmpeg_fingerprint.py
@@ -56,7 +56,7 @@ def check_frames_already_exist(path, frame_nb):
     return True
 
 
-def get_fingerprint_ffmpeg(path, frame_nb, log_level=1, log_file=False, log_timestamp=None):
+def get_fingerprint_ffmpeg(path, frame_nb, log_level=1, log_file=False, log_timestamp=None, cleanup=False):
     global session_timestamp
 
     if path is None or path == '' or frame_nb == 0:
@@ -87,10 +87,11 @@ def get_fingerprint_ffmpeg(path, frame_nb, log_level=1, log_file=False, log_time
         except BaseException as err:
             print_debug(a=["Error - Possible Corruption - frame file error: %s : %s" % (filename, err.strerror)], log=log_level > 0, log_file=log_file)
             break
-    try:
-        shutil.rmtree(Path(data_path / 'fingerprints' / replace(path) / 'frames'))
-    except OSError as e:
-        print_debug(a=["Error: %s : %s" % (Path(data_path / 'fingerprints' / replace(path) / 'frames'), e.strerror)], log=log_level > 0, log_file=log_file)
+    if cleanup:
+        try:
+            shutil.rmtree(Path(data_path / 'fingerprints' / replace(path) / 'frames'))
+        except OSError as e:
+            print_debug(a=["Error: %s : %s" % (Path(data_path / 'fingerprints' / replace(path) / 'frames'), e.strerror)], log=log_level > 0, log_file=log_file)
     end = datetime.now()
     print_debug(a=["made hash in %s" % str(end - start)], log=log_level > 0, log_file=log_file)
     return video_fingerprint
@@ -146,7 +147,7 @@ def main(argv):
                 fps = video.get(cv2.CAP_PROP_FPS)
                 quarter_frames_or_first_X_mins = min(int(frames / 4), int(fps * 60 * max_fingerprint_mins))
                 video.release()
-                result = get_fingerprint_ffmpeg(path, quarter_frames_or_first_X_mins)
+                result = get_fingerprint_ffmpeg(path, quarter_frames_or_first_X_mins, log_level, True, None, cleanup)
         end = datetime.now()
         print_debug(["total runtime %s" % str(end - start)])
     else:


### PR DESCRIPTION
**Changes**
* when getting the list of common frames, start comparing at frame 1 instead of 0
* allow `ffmpeg_fingerprint.py` to optionally not delete the `frames` folder after running

**Issues**
fixes #12 
