### PR TITLE
Add changing the auto skipper cooldown time via env and cli param

### DIFF
--- a/.github/workflows/docker-deploy-skipper.yml
+++ b/.github/workflows/docker-deploy-skipper.yml
@@ -6,6 +6,7 @@ on:
       - master
     paths:
       - 'jellyfin_auto_skip.py'
+      - 'Dockerfile_Jellyfin-Intro-Skipper'
 
 env:
   IMAGE_NAME_SKIPPER: jellyfin-intro-skipper

--- a/.github/workflows/docker-test-build-skipper.yml
+++ b/.github/workflows/docker-test-build-skipper.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'jellyfin_auto_skip.py'
+      - 'Dockerfile_Jellyfin-Intro-Skipper'
 
 env:
   IMAGE_NAME_Skipper: jellyfin-intro-skipper-test

--- a/Dockerfile_Jellyfin-Intro-Skipper
+++ b/Dockerfile_Jellyfin-Intro-Skipper
@@ -7,6 +7,6 @@ RUN pip install --no-cache-dir wheel
 RUN pip install --no-cache-dir -r /app/requirements.txt
 WORKDIR /app
 ENTRYPOINT ["python"]
-CMD [ "-u", "jellyfin_auto_skip.py", "-a" ]
+CMD [ "-u", "jellyfin_auto_skip.py", "-a", "-c", "2" ]
 
 VOLUME /app/config

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -81,6 +81,7 @@ docker run -d \
 | Optional | ```-e DATA_DIR=/config/data``` | Use a different directory to store cached data. Modifying this will likely require a new path mapping such as ```-v /path/to/data:/data``` |
 |---
 | Optional | ```-e LOG_LEVEL=INFO/VERBOSE/DEBUG``` | Change the log level (default is verbose for docker) |
+| Optional | ```-e AUTO_SKIP_COOLDOWN=4``` | Specify the cooldown time (seconds) for the auto skipper (default 2) |
 {:.table-striped}
 
 ### Docker with network shares

--- a/jellyfin_auto_skip.py
+++ b/jellyfin_auto_skip.py
@@ -15,7 +15,7 @@ server_username = os.environ['JELLYFIN_USERNAME'] if 'JELLYFIN_USERNAME' in os.e
 server_password = os.environ['JELLYFIN_PASSWORD'] if 'JELLYFIN_PASSWORD' in os.environ else ''
 
 mon_all_users = os.environ['MONITOR_ALL_USERS'] if 'MONITOR_ALL_USERS' in os.environ else ''
-env_cooldown_str = os.environ['COOLDOWN_SEC'] if 'COOLDOWN_SEC' in os.environ else ''
+env_cooldown_str = os.environ['AUTO_SKIP_COOLDOWN'] if 'AUTO_SKIP_COOLDOWN' in os.environ else ''
 
 config_path = Path(os.environ['CONFIG_DIR']) if 'CONFIG_DIR' in os.environ else Path(Path.cwd() / 'config')
 data_path = Path(os.environ['DATA_DIR']) if 'DATA_DIR' in os.environ else Path(config_path / 'data')

--- a/jellyfin_auto_skip.py
+++ b/jellyfin_auto_skip.py
@@ -15,6 +15,7 @@ server_username = os.environ['JELLYFIN_USERNAME'] if 'JELLYFIN_USERNAME' in os.e
 server_password = os.environ['JELLYFIN_PASSWORD'] if 'JELLYFIN_PASSWORD' in os.environ else ''
 
 mon_all_users = os.environ['MONITOR_ALL_USERS'] if 'MONITOR_ALL_USERS' in os.environ else ''
+env_cooldown_str = os.environ['COOLDOWN_SEC'] if 'COOLDOWN_SEC' in os.environ else ''
 
 config_path = Path(os.environ['CONFIG_DIR']) if 'CONFIG_DIR' in os.environ else Path(Path.cwd() / 'config')
 data_path = Path(os.environ['DATA_DIR']) if 'DATA_DIR' in os.environ else Path(config_path / 'data')
@@ -22,6 +23,7 @@ data_path = Path(os.environ['DATA_DIR']) if 'DATA_DIR' in os.environ else Path(c
 TICKS_PER_MS = 10000
 preroll_seconds = 3
 minimum_intro_length = 10  # seconds
+cooldown_time = 5
 
 client = None
 should_exit = False
@@ -151,17 +153,19 @@ def monitor_loop(monitor_all_users=False):
     if server_url == '' or server_username == '' or server_password == '':
         print('missing server info')
         return
-    
+
     init_client()
     if should_exit:
         return
 
     print('will monitor [%s]' % ('all users' if monitor_all_users else 'current user'))
+    print('cooldown between check-ins is set to %s seconds' % cooldown_time)
     print('listening for jellyfin sessions...')
     while not should_exit:
         if not monitor_sessions(monitor_all_users) and not should_exit:
             init_client()
-        sleep(5)
+        sleep(cooldown_time)
+
     if client is not None:
         try:
             jellyfin_logout()
@@ -172,10 +176,12 @@ def monitor_loop(monitor_all_users=False):
 
 
 def main(argv):
+    global cooldown_time
+
     all_users = mon_all_users
 
     try:
-        opts, args = getopt.getopt(argv, "ha")
+        opts, args = getopt.getopt(argv, 'hac:', ['cooldown'])
     except getopt.GetoptError:
         print('jellyfin_auto_skip.py -a (all users)\n')
         sys.exit(2)
@@ -186,6 +192,11 @@ def main(argv):
             sys.exit()
         elif opt == '-a':
             all_users = True
+        elif opt in ('-c', '--cooldown'):
+            if arg != '' and arg.isnumeric():
+                cooldown_nb = int(arg)
+                if cooldown_nb > 0 and cooldown_nb < 300:
+                    cooldown_time = cooldown_nb
     
     if server_url == '' or server_username == '' or server_password == '':
         print('you need to export env variables: JELLYFIN_URL, JELLYFIN_USERNAME, JELLYFIN_PASSWORD\n')
@@ -195,6 +206,11 @@ def main(argv):
         all_users = True
     elif mon_all_users == 'FALSE':
         all_users = False
+    
+    if env_cooldown_str != '' and env_cooldown_str.isnumeric():
+        cooldown_nb = int(env_cooldown_str)
+        if cooldown_nb > 0 and cooldown_nb < 300:
+            cooldown_time = cooldown_nb
 
     monitor_loop(all_users)
 


### PR DESCRIPTION
**Changes**
* use `-c 6` or `--cooldown 6` via cli, `AUTO_SKIP_COOLDOWN=6` via environment variable, to set cooldown
* updated the docs
* updated the auto skipper dockerfile to use 2 second cooldown instead of the old default of 5
* updated the auto skipper workflows to trigger when its dockerfile is modified
