### PR TITLE
output ffmpeg to pipe

### DIFF
--- a/decode.py
+++ b/decode.py
@@ -89,7 +89,7 @@ def create_video_fingerprint(profile, hashfps, log_level, log_file):
     video_fingerprint = []
 
     quarter_frames_or_first_X_mins = min(floor(((profile['total_frames'] / profile['fps']) / 4) * hashfps), floor(max_fingerprint_mins * 60 * hashfps))
-    video_fingerprint = get_fingerprint_ffmpeg(profile['Path'], hashfps, quarter_frames_or_first_X_mins, log_level, log_file, session_timestamp, True)
+    video_fingerprint = get_fingerprint_ffmpeg(profile['Path'], hashfps, quarter_frames_or_first_X_mins, log_level, log_file, session_timestamp)
 
     return video_fingerprint
 
@@ -445,6 +445,8 @@ def process_directory(profiles=[], ref_profile=None, hashfps=2, log_level=0, log
     start = datetime.now()
     print_debug(a=['started at', start], log=log_level > 0, log_file=log_file)
     print_debug(a=["Check Frame: %s\n" % str(check_frame)], log=log_level > 0, log_file=log_file)
+    print_debug(a=["Hash fps: %s\n" % str(hash_fps)], log=log_level > 0, log_file=log_file)
+
     if cleanup:
         print_debug(a=['fingerprint files will be cleaned up'], log=log_level > 0, log_file=log_file)
 

--- a/ffmpeg_fingerprint.py
+++ b/ffmpeg_fingerprint.py
@@ -2,7 +2,6 @@ import os
 import re
 import cv2
 import imagehash
-import shutil
 import sys
 import getopt
 from subprocess import Popen, PIPE, SubprocessError

--- a/ffmpeg_fingerprint.py
+++ b/ffmpeg_fingerprint.py
@@ -53,7 +53,7 @@ def get_frames(path, hash_fps, frame_nb, log_level, log_file):
     command = ["ffmpeg", "-i", path, "-vf", 'fps=%s' % str(hash_fps), "-frames:v", str(frame_nb), "-f", "image2pipe", "-pix_fmt", "rgb24", "-vcodec", "rawvideo", "-s", "384x216", "-"]
 
     with Path(os.devnull).open('w') as devnull_fp:
-        proc = subprocess.Popen(command, stdout=subprocess.PIPE, bufsize=10**8)
+        proc = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=devnull_fp, bufsize=10**8)
 
         filein = proc.stdout
         bytes_list = []


### PR DESCRIPTION
**Changes**
*Instead of ffmpeg saving frames to disk as individual image files, pipe the frames to stdout as RGB24 (width x height x 3 bytes), and store the bytes in a list. Then once ffmpeg exits, process the list into PIL objects. Depending on how IO bottlenecked the system is, this can yield around 30% faster frame extraction
